### PR TITLE
[MNT] - Fix for numpy update

### DIFF
--- a/hsntools/sorting/utils.py
+++ b/hsntools/sorting/utils.py
@@ -62,7 +62,7 @@ def get_group_labels(class_labels, groups):
 
     group_labels = np.zeros(len(class_labels), dtype=int)
     for ind, cval in enumerate(class_labels):
-        group_labels[ind] = groups[:, 1][cval == groups[:, 0]]
+        group_labels[ind] = groups[:, 1][cval == groups[:, 0]][0]
 
     return group_labels
 


### PR DESCRIPTION
Newer numpy versions do not like it if you try to put a single-element array into another array. This updates a function where we did that (`get_group_labels`) to unpack the array first.